### PR TITLE
Add unified tool launcher GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # 羽球場標記工具
-## 使用說明
-## 輸出
 
-# 影片分割工具
-## 使用說明
-## 輸出
+本專案包含三個 PyQt6 GUI 工具：
+
+* **32 點標記工具** – `gui_tool.MainWindow`
+* **資料集輸出工具** – `output_tool/output_tool_gui.MainWindow`
+* **影片分割工具** – `video_split_tool/split_tool.VideoFrameExtractor`
+
+現在可以透過新的 `launcher.py` 一站式啟動。執行：
+
+```bash
+python launcher.py
+```
+
+點選相應按鈕即可開啟所需的工具視窗。

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sys
+from PyQt6.QtWidgets import QApplication, QWidget, QPushButton, QVBoxLayout
+
+from gui_tool import MainWindow as MarkerWindow
+from output_tool.output_tool_gui import MainWindow as OutputWindow
+from video_split_tool.split_tool import VideoFrameExtractor
+
+
+class Launcher(QWidget):
+    """Simple window to choose which tool to start."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Tool Launcher")
+        layout = QVBoxLayout(self)
+
+        btn_marker = QPushButton("32-Point Marker")
+        btn_output = QPushButton("Dataset Builder")
+        btn_split = QPushButton("Video Split Tool")
+
+        layout.addWidget(btn_marker)
+        layout.addWidget(btn_output)
+        layout.addWidget(btn_split)
+
+        btn_marker.clicked.connect(self.open_marker)
+        btn_output.clicked.connect(self.open_output)
+        btn_split.clicked.connect(self.open_split)
+
+        self._marker_window: MarkerWindow | None = None
+        self._output_window: OutputWindow | None = None
+        self._split_window: VideoFrameExtractor | None = None
+
+    # --- open windows ---
+    def open_marker(self) -> None:
+        if self._marker_window is None:
+            self._marker_window = MarkerWindow()
+        self._marker_window.show()
+
+    def open_output(self) -> None:
+        if self._output_window is None:
+            self._output_window = OutputWindow()
+        self._output_window.show()
+
+    def open_split(self) -> None:
+        if self._split_window is None:
+            self._split_window = VideoFrameExtractor()
+        self._split_window.show()
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    launcher = Launcher()
+    launcher.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,35 +1,15 @@
 #!/usr/bin/env python3
-"""mark32.py – PyQt6 羽球場 32 點標記工具（表格版 + 自動連線）
-
-功能一覽
-========
-* 左鍵標點：即時把 X/Y 寫入表格並自動跳到下一列。
-* 右鍵清空：座標設為 Null，畫布移除標記，Is Null 會被打勾。
-* Visible = Checked → 畫圓點；Unchecked → 畫 X。
-* 勾選 Is Null → 取消顯示。
-* 依照 EDGES 對照表自動連線，並用 color_name 指定顏色。
-
-依序改動
---------
-1. 新增 `EDGES` & `PENS` 常數來定義要連的線段與顏色。
-2. `ImageCanvas` 新增 `edge_items` 字典 + `update_edges_for()` 來管理線段。
-3. 在標點、清空、Visible/Null 變動時都呼叫 `update_edges_for()`。
-4. `load_image()` 載入舊點後呼叫一次所有 `update_edges_for()`，確保重畫連線。
-"""
-
+"""Entry point for selecting different GUI tools."""
 from __future__ import annotations
 
-import faulthandler
-import signal
 import sys
-from PyQt6.QtWidgets import (
-    QApplication
-)
-from gui_tool import MainWindow
+from PyQt6.QtWidgets import QApplication
 
-# ---------- main ----------
-if __name__=="__main__":
+from launcher import Launcher
+
+
+if __name__ == "__main__":
     app = QApplication(sys.argv)
-    mw = MainWindow()
-    mw.show()
+    win = Launcher()
+    win.show()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- add `launcher.py` to provide a central GUI to open marking, dataset and video split tools
- rework `main.py` to use the launcher
- document new usage in README

## Testing
- `python -m py_compile launcher.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68404070ad848323adda1c85d6636761